### PR TITLE
Fixed build for strict modern compilers (LLVM, GCC)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,15 @@
 *.i*86
 *.x86_64
 *.hex
+playtape
+tape2wav
 
 # Debug files
 *.dSYM/
+
+# VSCode artifacts
+**/.vscode/
+
+# CLion / IntelliJ
+**/.idea/
+

--- a/src/tape2wav.c
+++ b/src/tape2wav.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
+#include <unistd.h>
 #include <errno.h>
 
 #define BUFFER_SIZE 4096

--- a/src/tzx.c
+++ b/src/tzx.c
@@ -8,6 +8,7 @@ Copyright (c) 2007 Fredrick Meunier
 #include <tzx.h>
 #include <libspectrum.h>
 #include <coro.h>
+#include <string.h>
 
 /* ZX Spectrum clock */
 #define MHZ 3500000ULL


### PR DESCRIPTION
Build fix for Apple LLVM (and recent GCC version)